### PR TITLE
Adds DATABASE_URL to config.json for Heroku Postgres setup

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -21,6 +21,7 @@
     "database": "sweater-weather-express_production",
     "host": "127.0.0.1",
     "dialect": "postgres",
-    "operatorsAliases": false
+    "operatorsAliases": false,
+    "use_env_variable": "DATABASE_URL"
   }
 }


### PR DESCRIPTION
Following this doc:
https://sequelize.readthedocs.io/en/1.7.0/articles/heroku/